### PR TITLE
Information about the dependency: curl and cmake

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -20,6 +20,7 @@ Then:
 #### On Linux
 
 1. Unzip the downloaded folder and place it in your home directory.
+2. Make sure to have dependencies curl and cmake installed.
 
 ## Getting Atom & Juno
 


### PR DESCRIPTION
Many are facing a problem of build errors with package MbedTLS. Installing curl and cmake solves the problem.