### PR TITLE
add `indent-detective` to auto installed packages

### DIFF
--- a/lib/packages.coffee
+++ b/lib/packages.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 requirements = [
   'tool-bar'
   'highlight-selected'
+  'indent-detective'
   'latex-completions'
   'language-julia'
   'ink'


### PR DESCRIPTION
Should release a tag with https://github.com/JunoLab/atom-indent-detective/pull/4 merged though, otherwise the package doesn't work properly.