### PR TITLE
install language-markdown automatically

### DIFF
--- a/lib/packages.coffee
+++ b/lib/packages.coffee
@@ -5,6 +5,7 @@ requirements = [
   'indent-detective'
   'latex-completions'
   'language-julia'
+  'language-markdown'
   'ink'
   'julia-client'
 ]


### PR DESCRIPTION
So markdown highlighting in docstrings works by default, ref https://github.com/JuliaEditorSupport/atom-language-julia/pull/124.