### PR TITLE
fix reserved keywork `package`

### DIFF
--- a/lib/incompatible-packages.js
+++ b/lib/incompatible-packages.js
@@ -2,9 +2,9 @@
 
 export function checkIncompatible () {
   let incompat = []
-  for (let package of atom.packages.getLoadedPackages()) {
-    if (!package.isCompatible()) {
-      incompat.push(package)
+  for (let package_ of atom.packages.getLoadedPackages()) {
+    if (!package_.isCompatible()) {
+      incompat.push(package_)
     }
   }
 

--- a/lib/incompatible-packages.js
+++ b/lib/incompatible-packages.js
@@ -2,9 +2,9 @@
 
 export function checkIncompatible () {
   let incompat = []
-  for (let package_ of atom.packages.getLoadedPackages()) {
-    if (!package_.isCompatible()) {
-      incompat.push(package_)
+  for (let pkg of atom.packages.getLoadedPackages()) {
+    if (!pkg.isCompatible()) {
+      incompat.push(pkg)
     }
   }
 


### PR DESCRIPTION
Since Atom was killed the community came together and made a fork called [Pulsar}(https://github.com/pulsar-edit/pulsar).
It has updated a lot of parts in the editor.
This also changed the javascript version that was used. In the newer one `package` is a keyword and can't be used as variable name.
This fixes the issue.

It would be nice if a new version with this fix could be [published to the new packend](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#publishing). If there are any problems you can create an issue on the github repo.